### PR TITLE
fix(rollup): fix Browser/Universal bundle terser options, remove all …

### DIFF
--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -89,7 +89,7 @@ export default [
           gzipPlugin(),
           terser({
             format: {
-              comments: 'all',
+              comments: false,
             },
           }),
         ],
@@ -110,7 +110,7 @@ export default [
           gzipPlugin(),
           terser({
             format: {
-              comments: 'all',
+              comments: false,
             },
           }),
         ],


### PR DESCRIPTION
Fix for previous release, comments should be removed from all Browser and Universal bundles.  Changed terser plugin comment options from `"all"` to `false`. 

The canary repo (vin-decoder) was failing tests and builds due to this.